### PR TITLE
Add interactable tiles for better tilemap creation

### DIFF
--- a/Prefabs/BaseCollectible.tscn
+++ b/Prefabs/BaseCollectible.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=2 format=3 uid="uid://c3a514exc62vs"]
+
+[ext_resource type="Texture2D" uid="uid://ckwaonuw5sri4" path="res://Sprites/Tilesets/interactables_spritesheet.png" id="1_wi0x1"]
+
+[node name="BaseCollectible" type="Area2D"]
+collision_layer = 8
+monitorable = false
+
+[node name="Sprite" type="Sprite2D" parent="."]
+texture = ExtResource("1_wi0x1")
+hframes = 5
+vframes = 3
+frame = 2
+
+[node name="Shape" type="CollisionShape2D" parent="."]

--- a/Prefabs/BasePlayer.tscn
+++ b/Prefabs/BasePlayer.tscn
@@ -22,6 +22,7 @@ _data = {
 
 [node name="Player" type="CharacterBody2D" node_paths=PackedStringArray("CS")]
 z_index = 1
+collision_mask = 15
 safe_margin = 0.001
 script = ExtResource("1_llowg")
 CS = NodePath("Shape")

--- a/Prefabs/BasePlayer.tscn
+++ b/Prefabs/BasePlayer.tscn
@@ -1,6 +1,7 @@
 [gd_scene load_steps=8 format=3 uid="uid://blji4xi2wujrn"]
 
 [ext_resource type="Script" path="res://Scripts/Player/PlayerCharacter.gd" id="1_llowg"]
+[ext_resource type="PackedScene" uid="uid://b840s1vtqdve8" path="res://Prefabs/Block.tscn" id="2_y55lc"]
 [ext_resource type="Texture2D" uid="uid://dv8tuujxo4snb" path="res://Sprites/Tilesets/characters_spritesheet.png" id="3_in1sb"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_y4m7f"]

--- a/Prefabs/BasePlayer.tscn
+++ b/Prefabs/BasePlayer.tscn
@@ -23,6 +23,7 @@ _data = {
 [node name="Player" type="CharacterBody2D" node_paths=PackedStringArray("CS")]
 z_index = 1
 collision_mask = 15
+platform_on_leave = 1
 safe_margin = 0.001
 script = ExtResource("1_llowg")
 CS = NodePath("Shape")

--- a/Prefabs/BasePlayer.tscn
+++ b/Prefabs/BasePlayer.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=8 format=3 uid="uid://blji4xi2wujrn"]
 
 [ext_resource type="Script" path="res://Scripts/Player/PlayerCharacter.gd" id="1_llowg"]
-[ext_resource type="PackedScene" uid="uid://bct4vg45dics6" path="res://Prefabs/Block.tscn" id="2_y55lc"]
+[ext_resource type="PackedScene" uid="uid://b840s1vtqdve8" path="res://Prefabs/Block.tscn" id="2_y55lc"]
 [ext_resource type="Texture2D" uid="uid://dv8tuujxo4snb" path="res://Sprites/Tilesets/characters_spritesheet.png" id="3_in1sb"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_y4m7f"]

--- a/Prefabs/BasePlayer.tscn
+++ b/Prefabs/BasePlayer.tscn
@@ -1,7 +1,6 @@
 [gd_scene load_steps=8 format=3 uid="uid://blji4xi2wujrn"]
 
 [ext_resource type="Script" path="res://Scripts/Player/PlayerCharacter.gd" id="1_llowg"]
-[ext_resource type="PackedScene" uid="uid://b840s1vtqdve8" path="res://Prefabs/Block.tscn" id="2_y55lc"]
 [ext_resource type="Texture2D" uid="uid://dv8tuujxo4snb" path="res://Sprites/Tilesets/characters_spritesheet.png" id="3_in1sb"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_y4m7f"]
@@ -22,8 +21,10 @@ _data = {
 
 [node name="Player" type="CharacterBody2D" node_paths=PackedStringArray("CS")]
 z_index = 1
-collision_mask = 31
+collision_mask = 319
 platform_on_leave = 1
+platform_floor_layers = 2
+platform_wall_layers = 16
 safe_margin = 0.001
 script = ExtResource("1_llowg")
 CS = NodePath("Shape")

--- a/Prefabs/BasePlayer.tscn
+++ b/Prefabs/BasePlayer.tscn
@@ -22,7 +22,7 @@ _data = {
 
 [node name="Player" type="CharacterBody2D" node_paths=PackedStringArray("CS")]
 z_index = 1
-collision_mask = 15
+collision_mask = 31
 platform_on_leave = 1
 safe_margin = 0.001
 script = ExtResource("1_llowg")

--- a/Prefabs/BaseTouchable.tscn
+++ b/Prefabs/BaseTouchable.tscn
@@ -38,6 +38,7 @@ position = Vector2(0, -9)
 collision_layer = 16
 monitoring = false
 collision_layer = 32
+monitorable = false
 script = SubResource("GDScript_bq2oj")
 
 [node name="Sprite" type="Sprite2D" parent="."]

--- a/Prefabs/BaseTouchable.tscn
+++ b/Prefabs/BaseTouchable.tscn
@@ -1,10 +1,43 @@
-[gd_scene load_steps=2 format=3 uid="uid://bdhg2jk7wxbv4"]
+[gd_scene load_steps=3 format=3 uid="uid://bdhg2jk7wxbv4"]
 
 [ext_resource type="Texture2D" uid="uid://c2quooqnbmx40" path="res://Sprites/Tilesets/decorations_tilesheet.png" id="1_b5h4y"]
 
+[sub_resource type="GDScript" id="GDScript_bq2oj"]
+resource_name = "DynamicTouchInteractions"
+script/source = "#Libraries
+extends Area2D
+
+#Registration
+class_name DynamicTouchInteractions
+
+#Atributes
+var rotationOffset: float = 0.0
+
+#Method called once at start
+func _ready():
+	$Sprite.flip_h = randi() % 2 == 0
+
+
+#Method called on frame time updates
+func _process(_delta):
+	#Rotating based on collision movements
+	#rotate_toward(rotation_degrees, rotationOffset * 540,  _delta)
+	
+	#Reseting offset
+	rotationOffset -= _delta
+
+#Method called once every body-entering signal
+func _on_body_entered(body: Node):
+	#Detecting character collision
+	if body is CharacterBody2D:
+		rotationOffset = body.velocity.x
+"
+
 [node name="BaseTouchable" type="Area2D"]
 position = Vector2(0, -9)
+collision_layer = 16
 monitoring = false
+script = SubResource("GDScript_bq2oj")
 
 [node name="Sprite" type="Sprite2D" parent="."]
 position = Vector2(0, 18)
@@ -16,3 +49,5 @@ vframes = 9
 frame = 88
 
 [node name="Shape" type="CollisionShape2D" parent="."]
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/Prefabs/BaseTouchable.tscn
+++ b/Prefabs/BaseTouchable.tscn
@@ -37,6 +37,7 @@ func _on_body_entered(body: Node):
 position = Vector2(0, -9)
 collision_layer = 16
 monitoring = false
+collision_layer = 32
 script = SubResource("GDScript_bq2oj")
 
 [node name="Sprite" type="Sprite2D" parent="."]

--- a/Prefabs/BaseTouchable.tscn
+++ b/Prefabs/BaseTouchable.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=2 format=3 uid="uid://bdhg2jk7wxbv4"]
+
+[ext_resource type="Texture2D" uid="uid://c2quooqnbmx40" path="res://Sprites/Tilesets/decorations_tilesheet.png" id="1_b5h4y"]
+
+[node name="BaseTouchable" type="Area2D"]
+position = Vector2(0, -9)
+monitoring = false
+
+[node name="Sprite" type="Sprite2D" parent="."]
+position = Vector2(0, 18)
+texture = ExtResource("1_b5h4y")
+centered = false
+offset = Vector2(-9, -18)
+hframes = 22
+vframes = 9
+frame = 88
+
+[node name="Shape" type="CollisionShape2D" parent="."]

--- a/Prefabs/Block.tscn
+++ b/Prefabs/Block.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=3 format=3 uid="uid://bct4vg45dics6"]
+[gd_scene load_steps=3 format=3 uid="uid://b840s1vtqdve8"]
 
 [ext_resource type="Texture2D" uid="uid://w46lmkcnodey" path="res://Sprites/Tilesets/platforms_tilesheet.png" id="1_poagc"]
 
@@ -11,12 +11,10 @@ collision_mask = 2
 
 [node name="Sprite" type="Sprite2D" parent="."]
 texture_filter = 1
-position = Vector2(0, -9)
 texture = ExtResource("1_poagc")
 hframes = 37
 vframes = 14
 frame = 392
 
 [node name="Shape" type="CollisionShape2D" parent="."]
-position = Vector2(0, -9)
 shape = SubResource("RectangleShape2D_1dr15")

--- a/Prefabs/Block.tscn
+++ b/Prefabs/Block.tscn
@@ -6,15 +6,16 @@
 size = Vector2(18, 18)
 
 [node name="Block" type="StaticBody2D"]
-collision_layer = 2
-collision_mask = 2
+collision_layer = 4
 
 [node name="Sprite" type="Sprite2D" parent="."]
 texture_filter = 1
+position = Vector2(0, -9)
 texture = ExtResource("1_poagc")
 hframes = 37
 vframes = 14
 frame = 392
 
 [node name="Shape" type="CollisionShape2D" parent="."]
+position = Vector2(0, -9)
 shape = SubResource("RectangleShape2D_1dr15")

--- a/Prefabs/CoinCollectible.tscn
+++ b/Prefabs/CoinCollectible.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3 uid="uid://bb8gqc3qghseq"]
+
+[ext_resource type="PackedScene" uid="uid://dawb4eh7lqeht" path="res://Prefabs/BaseCollectible.tscn" id="1_hp5aq"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_lonma"]
+radius = 7.0
+
+[node name="CoinCollectible" instance=ExtResource("1_hp5aq")]
+
+[node name="Sprite" parent="." index="0"]
+frame = 1
+
+[node name="Shape" parent="." index="1"]
+shape = SubResource("CircleShape2D_lonma")

--- a/Prefabs/DiamondCollectible.tscn
+++ b/Prefabs/DiamondCollectible.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3 uid="uid://eh3vc7vr8e6p"]
+
+[ext_resource type="PackedScene" uid="uid://c3a514exc62vs" path="res://Prefabs/BaseCollectible.tscn" id="1_otusm"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_kt1kl"]
+radius = 8.0
+
+[node name="DiamondCollectible" instance=ExtResource("1_otusm")]
+
+[node name="Sprite" parent="." index="0"]
+frame = 0
+
+[node name="Shape" parent="." index="1"]
+shape = SubResource("CircleShape2D_kt1kl")

--- a/Prefabs/Door.tscn
+++ b/Prefabs/Door.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=3 format=3 uid="uid://d0b2ttm1a52o0"]
+
+[ext_resource type="Texture2D" uid="uid://c2quooqnbmx40" path="res://Sprites/Tilesets/decorations_tilesheet.png" id="1_tpbi6"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_yjobr"]
+size = Vector2(10, 18)
+
+[node name="Door" type="Area2D"]
+
+[node name="Sprite" type="Sprite2D" parent="."]
+texture = ExtResource("1_tpbi6")
+hframes = 22
+vframes = 9
+frame = 26
+
+[node name="Extra" type="Sprite2D" parent="."]
+position = Vector2(0, -18)
+texture = ExtResource("1_tpbi6")
+hframes = 22
+vframes = 9
+frame = 4
+
+[node name="Shape" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_yjobr")

--- a/Prefabs/FallingPlatform.tscn
+++ b/Prefabs/FallingPlatform.tscn
@@ -78,7 +78,7 @@ position = Vector2(0, -18)
 shape = SubResource("RectangleShape2D_tc724")
 
 [node name="Shape" type="CollisionShape2D" parent="."]
-position = Vector2(0, -13)
+position = Vector2(0, -4)
 shape = SubResource("RectangleShape2D_mj0ah")
 one_way_collision = true
 

--- a/Prefabs/FallingPlatform.tscn
+++ b/Prefabs/FallingPlatform.tscn
@@ -18,13 +18,13 @@ class_name FallingPlatform
 @export var time_till_deletion: float = 0.5
 var spawn_position: Vector2i
 
-#Method called on first frame
+#Method called once at start
 func _ready() -> void:
 	#Saving default position for respawning
 	if allow_respawn:
 		spawn_position = position
 
-#Method called on fixed time
+#Method called on fixed time updates
 func _physics_process(_delta: float) -> void:
 	if freeze == true and position.y != spawn_position.y:
 		position.y = move_toward(position.y, spawn_position.y, reset_speed * _delta)
@@ -39,6 +39,7 @@ func _on_body_entered(body: Node):
 		
 		#Handle resets
 		if allow_respawn:
+			#Platform respawn
 			await get_tree().create_timer(time_till_reset).timeout
 			set_deferred(\"freeze\", true)
 		else:
@@ -62,7 +63,6 @@ max_contacts_reported = 1
 script = SubResource("GDScript_ltq60")
 
 [node name="Sprite" type="Sprite2D" parent="."]
-position = Vector2(0, -9)
 texture = ExtResource("1_kjsq8")
 hframes = 37
 vframes = 14

--- a/Prefabs/FallingPlatform.tscn
+++ b/Prefabs/FallingPlatform.tscn
@@ -69,7 +69,9 @@ vframes = 14
 frame = 514
 
 [node name="Detection" type="Area2D" parent="."]
-collision_layer = 8
+position = Vector2(0, 9)
+collision_layer = 16
+monitorable = false
 
 [node name="Range" type="CollisionShape2D" parent="Detection"]
 position = Vector2(0, -18)

--- a/Prefabs/FallingPlatform.tscn
+++ b/Prefabs/FallingPlatform.tscn
@@ -1,0 +1,83 @@
+[gd_scene load_steps=5 format=3 uid="uid://bct4vg45dics6"]
+
+[ext_resource type="Texture2D" uid="uid://w46lmkcnodey" path="res://Sprites/Tilesets/platforms_tilesheet.png" id="1_kjsq8"]
+
+[sub_resource type="GDScript" id="GDScript_ltq60"]
+resource_name = "FallingPlatform"
+script/source = "#Libraries
+extends RigidBody2D
+
+#Registration
+class_name FallingPlatform
+
+#Attributes
+@export var time_till_fall: float = 0.5
+@export var allow_respawn: bool = true
+@export var time_till_reset: float = 1
+@export var reset_speed: int = 200
+@export var time_till_deletion: float = 0.5
+var spawn_position: Vector2i
+
+#Method called on first frame
+func _ready() -> void:
+	#Saving default position for respawning
+	if allow_respawn:
+		spawn_position = position
+
+#Method called on fixed time
+func _physics_process(_delta: float) -> void:
+	if freeze == true and position.y != spawn_position.y:
+		position.y = move_toward(position.y, spawn_position.y, reset_speed * _delta)
+
+#Method called once every body-entering signal
+func _on_body_entered(body: Node):
+	#Locking to only fall with player character
+	if body is CharacterBody2D:
+		#Handle death time
+		await get_tree().create_timer(time_till_fall).timeout
+		set_deferred(\"freeze\", false)
+		
+		#Handle resets
+		if allow_respawn:
+			await get_tree().create_timer(time_till_reset).timeout
+			set_deferred(\"freeze\", true)
+		else:
+			#Platform deletion
+			await get_tree().create_timer(time_till_fall).timeout
+			self.queue_free()
+"
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_tc724"]
+size = Vector2(18, 1.5)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_mj0ah"]
+size = Vector2(18, 10)
+
+[node name="FallingPlatform" type="RigidBody2D"]
+collision_layer = 8
+sleeping = true
+lock_rotation = true
+freeze = true
+max_contacts_reported = 1
+script = SubResource("GDScript_ltq60")
+
+[node name="Sprite" type="Sprite2D" parent="."]
+position = Vector2(0, -9)
+texture = ExtResource("1_kjsq8")
+hframes = 37
+vframes = 14
+frame = 514
+
+[node name="Detection" type="Area2D" parent="."]
+collision_layer = 8
+
+[node name="Range" type="CollisionShape2D" parent="Detection"]
+position = Vector2(0, -18)
+shape = SubResource("RectangleShape2D_tc724")
+
+[node name="Shape" type="CollisionShape2D" parent="."]
+position = Vector2(0, -13)
+shape = SubResource("RectangleShape2D_mj0ah")
+one_way_collision = true
+
+[connection signal="body_entered" from="Detection" to="." method="_on_body_entered"]

--- a/Prefabs/KeyCollectible.tscn
+++ b/Prefabs/KeyCollectible.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3 uid="uid://cg27de4b05b7r"]
+
+[ext_resource type="PackedScene" uid="uid://dawb4eh7lqeht" path="res://Prefabs/BaseCollectible.tscn" id="1_mc7lu"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_qybad"]
+radius = 8.0
+
+[node name="KeyCollectible" instance=ExtResource("1_mc7lu")]
+
+[node name="Sprite" parent="." index="0"]
+frame = 3
+
+[node name="Shape" parent="." index="1"]
+shape = SubResource("CircleShape2D_qybad")

--- a/Prefabs/Shelter.tscn
+++ b/Prefabs/Shelter.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=3 format=3 uid="uid://b65x3g3cs8cag"]
+
+[ext_resource type="Texture2D" uid="uid://c2quooqnbmx40" path="res://Sprites/Tilesets/decorations_tilesheet.png" id="1_1xmyo"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_q7kxv"]
+size = Vector2(6, 17.5)
+
+[node name="Shelter" type="Area2D"]
+monitoring = false
+
+[node name="Sprite" type="Sprite2D" parent="."]
+position = Vector2(6, 0)
+texture = ExtResource("1_1xmyo")
+hframes = 22
+vframes = 9
+frame = 75
+
+[node name="Shape" type="CollisionShape2D" parent="."]
+position = Vector2(0, -0.25)
+shape = SubResource("RectangleShape2D_q7kxv")

--- a/Prefabs/Shelter.tscn
+++ b/Prefabs/Shelter.tscn
@@ -7,6 +7,7 @@ size = Vector2(6, 17.5)
 
 [node name="Shelter" type="Area2D"]
 monitoring = false
+collision_layer = 4
 
 [node name="Sprite" type="Sprite2D" parent="."]
 position = Vector2(6, 0)

--- a/Prefabs/Shelter.tscn
+++ b/Prefabs/Shelter.tscn
@@ -6,8 +6,8 @@
 size = Vector2(6, 17.5)
 
 [node name="Shelter" type="Area2D"]
-monitoring = false
 collision_layer = 4
+monitorable = false
 
 [node name="Sprite" type="Sprite2D" parent="."]
 position = Vector2(6, 0)

--- a/Prefabs/ShortDryGrass.tscn
+++ b/Prefabs/ShortDryGrass.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=3 uid="uid://wleb7uprtj0n"]
+
+[ext_resource type="PackedScene" uid="uid://bdhg2jk7wxbv4" path="res://Prefabs/BaseTouchable.tscn" id="1_aosx1"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_qqerl"]
+size = Vector2(8, 6)
+
+[node name="ShortDryGrass" instance=ExtResource("1_aosx1")]
+position = Vector2(0, 9)
+
+[node name="Sprite" parent="." index="0"]
+position = Vector2(0, -9)
+offset = Vector2(-9, -9)
+frame = 146
+
+[node name="Shape" parent="." index="1"]
+position = Vector2(0, -3)
+shape = SubResource("RectangleShape2D_qqerl")

--- a/Prefabs/ShortDryVines.tscn
+++ b/Prefabs/ShortDryVines.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://bmjdfsb2dh8mi"]
+
+[ext_resource type="PackedScene" uid="uid://bdhg2jk7wxbv4" path="res://Prefabs/BaseTouchable.tscn" id="1_ejhar"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_yofh6"]
+size = Vector2(10, 10.5)
+
+[node name="ShortDryVines" instance=ExtResource("1_ejhar")]
+
+[node name="Sprite" parent="." index="0"]
+flip_v = true
+frame = 34
+
+[node name="Shape" parent="." index="1"]
+position = Vector2(0, 4.75)
+shape = SubResource("RectangleShape2D_yofh6")

--- a/Prefabs/Spykes.tscn
+++ b/Prefabs/Spykes.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=3 format=3 uid="uid://bjfhylyj4luj"]
+
+[ext_resource type="Texture2D" uid="uid://c2quooqnbmx40" path="res://Sprites/Tilesets/decorations_tilesheet.png" id="1_lkqdb"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_dhadl"]
+size = Vector2(14, 7)
+
+[node name="Spykes" type="Area2D"]
+z_index = 1
+collision_layer = 256
+monitoring = false
+
+[node name="Sprite" type="Sprite2D" parent="."]
+texture = ExtResource("1_lkqdb")
+hframes = 22
+vframes = 9
+frame = 166
+
+[node name="Shape" type="CollisionShape2D" parent="."]
+position = Vector2(0, 5.5)
+shape = SubResource("RectangleShape2D_dhadl")

--- a/Prefabs/TallDryGrass.tscn
+++ b/Prefabs/TallDryGrass.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=3 format=3 uid="uid://dubyy5jnjb2wi"]
+
+[ext_resource type="PackedScene" uid="uid://bdhg2jk7wxbv4" path="res://Prefabs/BaseTouchable.tscn" id="1_7v2l6"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_qgfxw"]
+size = Vector2(10, 12)
+
+[node name="TallDryGrass" instance=ExtResource("1_7v2l6")]
+position = Vector2(0, 9)
+
+[node name="Sprite" parent="." index="0"]
+position = Vector2(0, 0)
+frame = 147
+
+[node name="Shape" parent="." index="1"]
+position = Vector2(0, -6)
+shape = SubResource("RectangleShape2D_qgfxw")

--- a/Prefabs/TallDryVines.tscn
+++ b/Prefabs/TallDryVines.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://ia7usijrlkqn"]
+
+[ext_resource type="PackedScene" uid="uid://bdhg2jk7wxbv4" path="res://Prefabs/BaseTouchable.tscn" id="1_d2g44"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_gsqfi"]
+size = Vector2(10, 16)
+
+[node name="TallDryVines" instance=ExtResource("1_d2g44")]
+
+[node name="Sprite" parent="." index="0"]
+flip_v = true
+frame = 35
+
+[node name="Shape" parent="." index="1"]
+position = Vector2(0, 8)
+shape = SubResource("RectangleShape2D_gsqfi")

--- a/Scenes/test_scene.tscn
+++ b/Scenes/test_scene.tscn
@@ -8,8 +8,6 @@
 
 [node name="Player" parent="." instance=ExtResource("1_aeo7e")]
 position = Vector2(85, 162)
-collision_layer = 3
-collision_mask = 3
 move_speed = 120
 aero_speed = 120
 jump_force = -300

--- a/Scenes/test_scene.tscn
+++ b/Scenes/test_scene.tscn
@@ -8,10 +8,11 @@
 
 [node name="Player" parent="." instance=ExtResource("1_aeo7e")]
 position = Vector2(85, 162)
-move_speed = 120
-aero_speed = 120
-jump_force = -300
-fall_speed = -300
+move_speed = null
+aero_speed = null
+jump_force = null
+fall_speed = null
+resistance = null
 
 [node name="Horizon" type="TileMapLayer" parent="."]
 z_index = -5

--- a/Scripts/Player/PlayerCharacter.gd
+++ b/Scripts/Player/PlayerCharacter.gd
@@ -28,12 +28,12 @@ func _ready() -> void:
 	#Setting default state
 	SM.current_state = SM.states.get("Idle")
 
-#Frame time updates
+#Method called on frame time updates
 func _process(_delta: float) -> void:
 	#Delegate logic to current state
 	SM.manage(_delta, self)
 
-#Fixed time updates
+#Method called on fixed time updates
 func _physics_process(_delta: float) -> void:
 	#Energy loss
 	velocity.x = move_toward(velocity.x, 0, 5 * resistance * _delta)

--- a/Tilesets/base.tres
+++ b/Tilesets/base.tres
@@ -1,6 +1,17 @@
-[gd_resource type="TileSet" load_steps=3 format=3 uid="uid://bann38wla7hon"]
+[gd_resource type="TileSet" load_steps=15 format=3 uid="uid://bann38wla7hon"]
 
 [ext_resource type="Texture2D" uid="uid://w46lmkcnodey" path="res://Sprites/Tilesets/platforms_tilesheet.png" id="1_pxhq0"]
+[ext_resource type="PackedScene" uid="uid://d0b2ttm1a52o0" path="res://Prefabs/Door.tscn" id="2_440ta"]
+[ext_resource type="PackedScene" uid="uid://bct4vg45dics6" path="res://Prefabs/FallingPlatform.tscn" id="2_r3bq5"]
+[ext_resource type="PackedScene" uid="uid://b65x3g3cs8cag" path="res://Prefabs/Shelter.tscn" id="3_dmik0"]
+[ext_resource type="PackedScene" uid="uid://wleb7uprtj0n" path="res://Prefabs/ShortDryGrass.tscn" id="4_4a45i"]
+[ext_resource type="PackedScene" uid="uid://bmjdfsb2dh8mi" path="res://Prefabs/ShortDryVines.tscn" id="5_j1wi7"]
+[ext_resource type="PackedScene" uid="uid://bjfhylyj4luj" path="res://Prefabs/Spykes.tscn" id="5_ynhl3"]
+[ext_resource type="PackedScene" uid="uid://dubyy5jnjb2wi" path="res://Prefabs/TallDryGrass.tscn" id="6_ou268"]
+[ext_resource type="PackedScene" uid="uid://ia7usijrlkqn" path="res://Prefabs/TallDryVines.tscn" id="7_c6ecb"]
+[ext_resource type="PackedScene" uid="uid://eh3vc7vr8e6p" path="res://Prefabs/DiamondCollectible.tscn" id="7_m6jfh"]
+[ext_resource type="PackedScene" uid="uid://cg27de4b05b7r" path="res://Prefabs/KeyCollectible.tscn" id="8_aspyu"]
+[ext_resource type="PackedScene" uid="uid://bb8gqc3qghseq" path="res://Prefabs/CoinCollectible.tscn" id="9_ajho6"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_81juv"]
 resource_name = "tileset"
@@ -4228,6 +4239,20 @@ use_texture_padding = false
 16:12/0/terrains_peering_bit/right_side = 13
 16:12/0/terrains_peering_bit/left_side = 13
 
+[sub_resource type="TileSetScenesCollectionSource" id="TileSetScenesCollectionSource_0e0ym"]
+resource_name = "interactables"
+scenes/0/scene = ExtResource("2_440ta")
+scenes/1/scene = ExtResource("3_dmik0")
+scenes/2/scene = ExtResource("2_r3bq5")
+scenes/3/scene = ExtResource("5_ynhl3")
+scenes/4/scene = ExtResource("7_m6jfh")
+scenes/5/scene = ExtResource("8_aspyu")
+scenes/6/scene = ExtResource("9_ajho6")
+scenes/7/scene = ExtResource("4_4a45i")
+scenes/8/scene = ExtResource("6_ou268")
+scenes/9/scene = ExtResource("5_j1wi7")
+scenes/10/scene = ExtResource("7_c6ecb")
+
 [resource]
 tile_size = Vector2i(18, 18)
 physics_layer_0/collision_layer = 2
@@ -4356,3 +4381,4 @@ terrain_set_7/terrain_4/color = Color(0.28125, 0.5, 0.25, 1)
 terrain_set_7/terrain_5/name = "decorated_andesite"
 terrain_set_7/terrain_5/color = Color(0.25, 0.5, 0.3125, 1)
 sources/0 = SubResource("TileSetAtlasSource_81juv")
+sources/1 = SubResource("TileSetScenesCollectionSource_0e0ym")

--- a/Tilesets/base.tres
+++ b/Tilesets/base.tres
@@ -4230,7 +4230,7 @@ use_texture_padding = false
 
 [resource]
 tile_size = Vector2i(18, 18)
-physics_layer_0/collision_layer = 1
+physics_layer_0/collision_layer = 2
 terrain_set_0/mode = 0
 terrain_set_0/terrain_0/name = "grass"
 terrain_set_0/terrain_0/color = Color(0, 1, 0, 1)


### PR DESCRIPTION
# Interactables

### Resume
This branch updates colliding properties from objects and adds tilemap improvements for world building and dynamic tiles.

## Collectibles:
- Add diamond collectible tile. Temporal sprite will be replaced later.
- Add key collectible tile. Temporal sprite will be replaced later.
- Add coin collectible tile. Temporal sprite will be replaced later.

## Dangers:
- Add falling platform tile.
- Add simple falling platform script with custom behavior to test tilemap scene painting.
- Add spikes tile.

## Environmental:
- Add short dry grass tile.
- Add tall dry grass tile.
- Add short dry vines tile.
- Add tall dry vines tile.
- Add WIP script for managing touch behavior to interactable tiles like grasses.

## Collisions
- Update collision layer ordering for complex behaviors and better usability.

## Tiles
- Update tileset importing dynamic tiles as a custom Scenes Collection to paint.